### PR TITLE
Investigate null subscription for user

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -66,7 +66,7 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
                 s.current_period_end,
                 p.name as plan_name
             FROM users u
-            LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status = 'active'
+            LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status IN ('active', 'trialing')
             LEFT JOIN plans p ON s.plan_id = p.id
             WHERE u.id = $1
         `, [userId]);
@@ -192,7 +192,7 @@ export const adminRoutes = new Elysia({ prefix: '/admin' })
                 SUM(p.price_monthly) as mrr
             FROM subscriptions s
             JOIN plans p ON s.plan_id = p.id
-            WHERE s.status = 'active' AND p.price_monthly > 0
+            WHERE s.status IN ('active', 'trialing') AND p.price_monthly > 0
         `);
 
         return {

--- a/src/routes/favorites.js
+++ b/src/routes/favorites.js
@@ -82,7 +82,7 @@ export const favoritesRoutes = new Elysia({ prefix: '/favorites' })
       SELECT 
         COALESCE(p.max_favorites, 50) as max_favorites
       FROM users u
-      LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status = 'active'
+      LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status IN ('active', 'trialing')
       LEFT JOIN plans p ON s.plan_id = p.id
       WHERE u.id = $1
     `, [userId]);

--- a/src/routes/playlists.js
+++ b/src/routes/playlists.js
@@ -47,7 +47,7 @@ export const playlistRoutes = new Elysia({ prefix: '/playlists' })
       SELECT 
         COALESCE(p.max_playlists, 1) as max_playlists
       FROM users u
-      LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status = 'active'
+      LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status IN ('active', 'trialing')
       LEFT JOIN plans p ON s.plan_id = p.id
       WHERE u.id = $1
     `, [userId]);

--- a/src/routes/profiles.js
+++ b/src/routes/profiles.js
@@ -44,7 +44,7 @@ export const profileRoutes = new Elysia({ prefix: '/profiles' })
       SELECT 
         COALESCE(p.max_profiles, 1) as max_profiles
       FROM users u
-      LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status = 'active'
+      LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status IN ('active', 'trialing')
       LEFT JOIN plans p ON s.plan_id = p.id
       WHERE u.id = $1
     `, [userId]);

--- a/src/routes/resellers.js
+++ b/src/routes/resellers.js
@@ -34,9 +34,9 @@ export const resellerRoutes = new Elysia({ prefix: '/reseller' })
         const clientStats = await db.getOne(`
             SELECT 
                 COUNT(*) as total_clients,
-                COUNT(CASE WHEN s.status = 'active' THEN 1 END) as active_clients
+                COUNT(CASE WHEN s.status IN ('active', 'trialing') THEN 1 END) as active_clients
             FROM users u
-            LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status = 'active'
+            LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status IN ('active', 'trialing')
             WHERE u.parent_reseller_id = $1
         `, [resellerId]);
         
@@ -74,7 +74,7 @@ export const resellerRoutes = new Elysia({ prefix: '/reseller' })
                 s.status as subscription_status,
                 p.name as plan_name
             FROM users u
-            LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status = 'active'
+            LEFT JOIN subscriptions s ON u.id = s.user_id AND s.status IN ('active', 'trialing')
             LEFT JOIN plans p ON s.plan_id = p.id
             WHERE u.parent_reseller_id = $1
             ORDER BY u.created_at DESC

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -34,7 +34,7 @@ export const subscriptionRoutes = new Elysia({ prefix: '/subscriptions' })
                 p.features
             FROM subscriptions s
             JOIN plans p ON s.plan_id = p.id
-            WHERE s.user_id = $1 AND s.status = 'active'
+            WHERE s.user_id = $1 AND s.status IN ('active', 'trialing')
             ORDER BY s.created_at DESC
             LIMIT 1
         `, [userId]);
@@ -98,9 +98,9 @@ export const subscriptionRoutes = new Elysia({ prefix: '/subscriptions' })
             };
         }
 
-        // Check if user already has an active subscription
+        // Check if user already has an active or trialing subscription
         const existingSubscription = await db.getOne(
-            'SELECT * FROM subscriptions WHERE user_id = $1 AND status = \'active\'',
+            'SELECT * FROM subscriptions WHERE user_id = $1 AND status IN (\'active\', \'trialing\')',
             [userId]
         );
 
@@ -208,7 +208,7 @@ export const subscriptionRoutes = new Elysia({ prefix: '/subscriptions' })
 
         // Get current subscription
         const currentSubscription = await db.getOne(
-            'SELECT * FROM subscriptions WHERE user_id = $1 AND status = \'active\'',
+            'SELECT * FROM subscriptions WHERE user_id = $1 AND status IN (\'active\', \'trialing\')',
             [userId]
         );
 
@@ -295,7 +295,7 @@ export const subscriptionRoutes = new Elysia({ prefix: '/subscriptions' })
 
         // Get current subscription
         const subscription = await db.getOne(
-            'SELECT * FROM subscriptions WHERE user_id = $1 AND status = \'active\'',
+            'SELECT * FROM subscriptions WHERE user_id = $1 AND status IN (\'active\', \'trialing\')',
             [userId]
         );
 
@@ -349,7 +349,7 @@ export const subscriptionRoutes = new Elysia({ prefix: '/subscriptions' })
 
         // Get current subscription
         const subscription = await db.getOne(
-            'SELECT * FROM subscriptions WHERE user_id = $1 AND status = \'active\' AND cancel_at_period_end = TRUE',
+            'SELECT * FROM subscriptions WHERE user_id = $1 AND status IN (\'active\', \'trialing\') AND cancel_at_period_end = TRUE',
             [userId]
         );
 


### PR DESCRIPTION
Update subscription queries to include 'trialing' status, ensuring trial users' subscriptions are recognized across the application.

Previously, the application only queried for 'active' subscriptions. However, Stripe initially creates subscriptions with a 'trialing' status. This led to trial users not seeing their subscription details, not having their plan limits applied, and not appearing in admin/reseller dashboards as active clients. This change aligns the application's subscription status handling with Stripe's lifecycle.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6209303-a9c0-43d6-80d2-848b42f83b34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6209303-a9c0-43d6-80d2-848b42f83b34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

